### PR TITLE
fixed 403 error in notify qiwi server

### DIFF
--- a/pyqiwip2p/notify/__init__.py
+++ b/pyqiwip2p/notify/__init__.py
@@ -67,7 +67,7 @@ class QiwiNotify:
             def check_headers(self, headers):
                 if (
                     "content-type" in headers
-                    and headers["content-type"] == "application/json"
+                    and headers["content-type"] == "application/json;charset=UTF-8"
                     and "X-Api-Signature-SHA256" in headers
                 ):
                     return True


### PR DESCRIPTION
Работал с данной либой, пытаясь поднять и использовать сервер столкнулся с 403 ошибкой, вызванной несоответствием хедеров запроса к /qiwi_notify серверу.  На сегодняшний день киви посылает запросы со следующими Request Headers:

Remote-Addr: localhost
HOST: 0.0.0.0:<PORT>
CONNECTION: close
USER-AGENT: Java-http-client/11.0.11
ACCEPT: application/json
ACCEPT-ENCODING: *
X-API-SIGNATURE-SHA256: <x-api-signature>
Content-Type: application/json;charset=UTF-8
Content-Length: 366

Тут важен хедер Content-Type, в котором 'application/json;charset=UTF-8' а не просто 'application/json'. Это я и заменил в файле __init__.py
